### PR TITLE
Feature/regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@
 /esperio/esperio-springjms/target
 /doc/javadoc
 /esperio/doc/javadoc
+
+.idea/
+
+esper-parent.iml
+
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -47,8 +47,6 @@
 /doc/javadoc
 /esperio/doc/javadoc
 
+# JIdea IDE files
 .idea/
-
-esper-parent.iml
-
 *.iml

--- a/common/src/main/java/com/espertech/esper/common/internal/util/StringValue.java
+++ b/common/src/main/java/com/espertech/esper/common/internal/util/StringValue.java
@@ -18,6 +18,20 @@ public final class StringValue {
 
     /**
      * Parse the string literal consisting of text between double-quotes or single-quotes.
+     * This method will not perform unescape if it is not required as indicated by the second argument
+     * @param value is the text within double or single quotes
+     * @param requireUnescape indicates if value should be unescaped
+     * @return parsed value
+     */
+    public static String parseString(String value, boolean requireUnescape) {
+        if(!requireUnescape)
+            return value.substring(1, value.length() - 1);
+        else
+            return parseString(value);
+    }
+
+    /**
+     * Parse the string literal consisting of text between double-quotes or single-quotes.
      *
      * @param value is the text wthin double or single quotes
      * @return parsed value

--- a/regression-lib/src/main/java/com/espertech/esper/regressionlib/suite/expr/exprcore/ZoneFox.java
+++ b/regression-lib/src/main/java/com/espertech/esper/regressionlib/suite/expr/exprcore/ZoneFox.java
@@ -1,0 +1,52 @@
+/*
+ ***************************************************************************************
+ *  Copyright (C) 2006 EsperTech, Inc. All rights reserved.                            *
+ *  http://www.espertech.com/esper                                                     *
+ *  http://www.espertech.com                                                           *
+ *  ---------------------------------------------------------------------------------- *
+ *  The software in this package is published under the terms of the GPL license       *
+ *  a copy of which has been included with this distribution in the license.txt file.  *
+ ***************************************************************************************
+ */
+package com.espertech.esper.regressionlib.suite.expr.exprcore;
+
+import com.espertech.esper.common.internal.support.SupportBean_S0;
+import com.espertech.esper.regressionlib.framework.RegressionEnvironment;
+import com.espertech.esper.regressionlib.framework.RegressionExecution;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ZoneFox {
+    public static Collection<RegressionExecution> executions() {
+        ArrayList<RegressionExecution> executions = new ArrayList<>();
+        executions.add(new ExprCoreLikeRegexStartsWith());
+        executions.add(new ExprCoreLikeRegexSlashU());
+        return executions;
+    }
+
+    private static class ExprCoreLikeRegexStartsWith implements RegressionExecution {
+        public void run(RegressionEnvironment env) {
+            String epl = "@name('s0') select p00 as result from SupportBean_S0 where p00.startsWith('\\user\\bob')";
+            String expected = "\\user\\bob";
+            env.compileDeploy(epl).addListener("s0");
+            env.sendEventBean(new SupportBean_S0(-1, expected));
+            String actual = (String)env.listener("s0").assertOneGetNewAndReset().get("result");
+            assertEquals(actual, expected);
+            env.undeployAll();
+        }
+    }
+
+    private static class ExprCoreLikeRegexSlashU implements RegressionExecution {
+        public void run(RegressionEnvironment env) {
+            String epl = "@name('s0') select p00 regexp '.*\\\\user\\\\.*' as result from SupportBean_S0";
+            env.compileDeploy(epl).addListener("s0");
+            env.sendEventBean(new SupportBean_S0(-1, "\\user\\bob"));
+            assertTrue((Boolean) env.listener("s0").assertOneGetNewAndReset().get("result"));
+            env.undeployAll();
+        }
+    }
+}

--- a/regression-lib/src/main/java/com/espertech/esper/regressionlib/suite/expr/exprcore/ZoneFox.java
+++ b/regression-lib/src/main/java/com/espertech/esper/regressionlib/suite/expr/exprcore/ZoneFox.java
@@ -23,12 +23,12 @@ import static org.junit.Assert.assertTrue;
 public class ZoneFox {
     public static Collection<RegressionExecution> executions() {
         ArrayList<RegressionExecution> executions = new ArrayList<>();
-        executions.add(new ExprCoreLikeRegexStartsWith());
-        executions.add(new ExprCoreLikeRegexSlashU());
+        executions.add(new StartsWith());
+        executions.add(new RegexSlashU());
         return executions;
     }
 
-    private static class ExprCoreLikeRegexStartsWith implements RegressionExecution {
+    private static class StartsWith implements RegressionExecution {
         public void run(RegressionEnvironment env) {
             String epl = "@name('s0') select p00 as result from SupportBean_S0 where p00.startsWith('\\user\\bob')";
             String expected = "\\user\\bob";
@@ -40,7 +40,7 @@ public class ZoneFox {
         }
     }
 
-    private static class ExprCoreLikeRegexSlashU implements RegressionExecution {
+    private static class RegexSlashU implements RegressionExecution {
         public void run(RegressionEnvironment env) {
             String epl = "@name('s0') select p00 regexp '.*\\\\user\\\\.*' as result from SupportBean_S0";
             env.compileDeploy(epl).addListener("s0");

--- a/regression-run/src/test/java/com/espertech/esper/regressionrun/suite/expr/TestSuiteExprCore.java
+++ b/regression-run/src/test/java/com/espertech/esper/regressionrun/suite/expr/TestSuiteExprCore.java
@@ -38,6 +38,8 @@ public class TestSuiteExprCore extends TestCase {
         session = null;
     }
 
+    public void testZoneFox() { RegressionRunner.run(session, ZoneFox.executions()); }
+
     public void testExprCoreRelOp() {
         RegressionRunner.run(session, new ExprCoreRelOp());
     }


### PR DESCRIPTION
This PR fixes an issue with a `\u` sequence in a regex statement. A use-case for this is as following:  

> Find an event where the resource is regex `.*\\user\\.*` and a test event contains `\user\bob`.

**Before:** parser applies unescape method to any `RULE_stringconstant`. In case of a regex this results in applying a special parsing logic for a `\u` character sequence, as if it was a unicode symbol.

**After:** we keep the logic as is, apart when we detect we are parsing a regex. In this case, we only remove the wrapping qoutation marks (as before), but do not apply any unescaping.
